### PR TITLE
add bzip2 to all mashines

### DIFF
--- a/roles/prepare-all/tasks/main.yml
+++ b/roles/prepare-all/tasks/main.yml
@@ -4,3 +4,5 @@
 # - shell: rm -rf /var/local/*
 # - shell: rm -rf /var/log/cider-ci*
 # - shell: rm -rf /etc/init/cider-ci*
+
+- apt: pkg=bzip2 state=latest update_cache=yes cache_valid_time=3600


### PR DESCRIPTION
Would fix https://github.com/cider-ci/cider-ci/issues/15

There are also other traits that cannot be installed without bzip2 being around.