### PR TITLE
traits: nodejs: update to v6 (LTS)

### DIFF
--- a/traits/nodejs/tasks/main.yml
+++ b/traits/nodejs/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Configure APT for nodejs
-  shell: curl -sL https://deb.nodesource.com/setup_4.x | bash -
+  shell: curl -sL https://deb.nodesource.com/setup_6.x | bash -
   tags: [internet]
 
 - name: Install node.js


### PR DESCRIPTION
confirmed that it works by manually trying it out on an executor:

```sh
root@ci-g2016-01:~# node -v
v6.10.1
```